### PR TITLE
Enforce engineering lifecycle safety gate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,6 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify safety scan controls
+        shell: pwsh
+        run: ./test/Test-SafetyScan.ps1
+      - name: Scan pull request diff
+        shell: bash
+        run: |
+          git diff --no-ext-diff --unified=0 "origin/${{ github.base_ref }}...HEAD" > lifecycle.diff
+          pwsh -File ./scripts/Invoke-SafetyScan.ps1 -DiffPath lifecycle.diff
       - uses: actions/configure-pages@v5
         id: pages
       - uses: actions/jekyll-build-pages@v1

--- a/STATE.md
+++ b/STATE.md
@@ -2,10 +2,8 @@
 
 ## Current
 
-Engineering-lifecycle alignment is implemented and pushed on
-codex/align-engineering-lifecycle. Draft PR creation is blocked because the
-connected GitHub integration returned 403 Resource not accessible by
-integration.
+The engineering lifecycle is represented by draft PRs and is ready for human
+review. The rebuild is PR #3; its stacked lifecycle alignment is PR #4.
 
 ## Done
 
@@ -13,12 +11,12 @@ integration.
 - Added GitHub Pages validation and deployment workflows.
 - Audited the rebuild against the canonical engineering lifecycle at D:\AGENTS.md.
 - Added and verified the lifecycle safety scan and its positive/negative controls.
+- Opened rebuild draft PR #3 and stacked lifecycle draft PR #4.
 
 ## Next
 
-Create the stacked draft PR from codex/align-engineering-lifecycle into
-feat/rebuild-engineering-blog at:
-https://github.com/rioscesar/rioscesar.github.io/pull/new/codex/align-engineering-lifecycle
+Review and approve the rebuild draft PR first, then review the stacked lifecycle
+draft PR. Do not merge automatically.
 
 ## Decisions
 
@@ -26,6 +24,6 @@ https://github.com/rioscesar/rioscesar.github.io/pull/new/codex/align-engineerin
   repository; this file is the repository-local continuity record they require.
 - The safety scan uses high-signal patterns only. It is intentionally small and
   supplements, rather than replaces, GitHub secret scanning and human review.
-- The GitHub integration can push branches but cannot create pull requests; use
-  the GitHub web link above or grant pull-request write permission before the
-  next implementation handoff.
+- The GitHub integration can push branches but cannot create pull requests.
+  GitHub CLI works after gh auth login --hostname github.com --git-protocol https
+  --web; use it for future PR creation and verify with gh auth status.

--- a/STATE.md
+++ b/STATE.md
@@ -2,21 +2,23 @@
 
 ## Current
 
-Engineering-lifecycle alignment is in progress on the branch
-codex/align-engineering-lifecycle. The implementation adds a deterministic
-safety scan, its controlled self-test, and a continuity record without changing
-the public site.
+Engineering-lifecycle alignment is implemented and pushed on
+codex/align-engineering-lifecycle. Draft PR creation is blocked because the
+connected GitHub integration returned 403 Resource not accessible by
+integration.
 
 ## Done
 
 - Rebuilt the legacy Jekyll Now site on feat/rebuild-engineering-blog.
 - Added GitHub Pages validation and deployment workflows.
 - Audited the rebuild against the canonical engineering lifecycle at D:\AGENTS.md.
+- Added and verified the lifecycle safety scan and its positive/negative controls.
 
 ## Next
 
-Run the safety-scan controls, validate the changed-file scope and Jekyll
-workflow, then open a stacked draft PR against feat/rebuild-engineering-blog.
+Create the stacked draft PR from codex/align-engineering-lifecycle into
+feat/rebuild-engineering-blog at:
+https://github.com/rioscesar/rioscesar.github.io/pull/new/codex/align-engineering-lifecycle
 
 ## Decisions
 
@@ -24,3 +26,6 @@ workflow, then open a stacked draft PR against feat/rebuild-engineering-blog.
   repository; this file is the repository-local continuity record they require.
 - The safety scan uses high-signal patterns only. It is intentionally small and
   supplements, rather than replaces, GitHub secret scanning and human review.
+- The GitHub integration can push branches but cannot create pull requests; use
+  the GitHub web link above or grant pull-request write permission before the
+  next implementation handoff.

--- a/STATE.md
+++ b/STATE.md
@@ -1,0 +1,26 @@
+# Project state
+
+## Current
+
+Engineering-lifecycle alignment is in progress on the branch
+codex/align-engineering-lifecycle. The implementation adds a deterministic
+safety scan, its controlled self-test, and a continuity record without changing
+the public site.
+
+## Done
+
+- Rebuilt the legacy Jekyll Now site on feat/rebuild-engineering-blog.
+- Added GitHub Pages validation and deployment workflows.
+- Audited the rebuild against the canonical engineering lifecycle at D:\AGENTS.md.
+
+## Next
+
+Run the safety-scan controls, validate the changed-file scope and Jekyll
+workflow, then open a stacked draft PR against feat/rebuild-engineering-blog.
+
+## Decisions
+
+- The canonical AGENTS.md and AI Workflow Kit are maintained outside this
+  repository; this file is the repository-local continuity record they require.
+- The safety scan uses high-signal patterns only. It is intentionally small and
+  supplements, rather than replaces, GitHub secret scanning and human review.

--- a/scripts/Invoke-SafetyScan.ps1
+++ b/scripts/Invoke-SafetyScan.ps1
@@ -1,0 +1,52 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$DiffPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $DiffPath -PathType Leaf)) {
+    throw "Diff file not found: $DiffPath"
+}
+
+$diff = Get-Content -LiteralPath $DiffPath -Raw
+$rules = @(
+    @{
+        Name = 'credential assignment'
+        Pattern = '(?im)\b(api[_-]?key|secret|password|passwd)\b\s*[:=]\s*[^#\s]+'
+    },
+    @{
+        Name = 'private key'
+        Pattern = '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+    },
+    @{
+        Name = 'GitHub token'
+        Pattern = '\bghp_[0-9A-Za-z]{36}\b'
+    },
+    @{
+        Name = 'AWS access key'
+        Pattern = '\bAKIA[0-9A-Z]{16}\b'
+    },
+    @{
+        Name = 'email address'
+        Pattern = '(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b'
+    },
+    @{
+        Name = 'US Social Security number'
+        Pattern = '\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b'
+    }
+)
+
+$hits = foreach ($rule in $rules) {
+    if ([regex]::IsMatch($diff, $rule.Pattern)) {
+        $rule.Name
+    }
+}
+
+if ($hits) {
+    Write-Error ("Safety scan failed: " + ($hits -join ', '))
+    exit 1
+}
+
+Write-Output 'Safety scan passed.'

--- a/test/Test-SafetyScan.ps1
+++ b/test/Test-SafetyScan.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = 'Stop'
+
+$scan = Join-Path $PSScriptRoot '..\scripts\Invoke-SafetyScan.ps1'
+$workspace = Join-Path ([System.IO.Path]::GetTempPath()) ("safety-scan-" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $workspace | Out-Null
+
+try {
+    $cleanDiff = Join-Path $workspace 'clean.diff'
+    Set-Content -LiteralPath $cleanDiff -Value '+Documentation-only change.' -NoNewline
+    & pwsh -NoProfile -File $scan -DiffPath $cleanDiff
+    if ($LASTEXITCODE -ne 0) {
+        throw 'Negative control failed: a clean diff was flagged.'
+    }
+
+    $badDiff = Join-Path $workspace 'bad.diff'
+    $badLine = '+api' + '_key=not-a-real-secret'
+    Set-Content -LiteralPath $badDiff -Value $badLine -NoNewline
+    & pwsh -NoProfile -File $scan -DiffPath $badDiff 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        throw 'Positive control failed: a credential assignment was not flagged.'
+    }
+
+    Write-Output 'Safety scan controls passed.'
+}
+finally {
+    Remove-Item -LiteralPath $workspace -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Adds the minimum repository support required by the canonical engineering lifecycle.

- Adds STATE.md as the project continuity record.
- Adds a deterministic safety scan for high-signal credential and PII patterns.
- Adds positive and negative controls for the scan.
- Runs the controls and pull-request diff scan before the Jekyll build.

## Validation

- pwsh -NoProfile -File .\test\Test-SafetyScan.ps1 passed: the clean control remained quiet and the credential-assignment control was detected.
- The staged diff passed scripts/Invoke-SafetyScan.ps1.
- git diff --check passed.

## Stacking

This draft targets the rebuild branch so the lifecycle change stays separate from master until the foundation is reviewed.