### PR TITLE
Add dark editorial theme

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -3,7 +3,8 @@
 ## Current
 
 The engineering lifecycle is represented by draft PRs and is ready for human
-review. The rebuild is PR #3; its stacked lifecycle alignment is PR #4.
+review. The rebuild is PR #3, its stacked lifecycle alignment is PR #4, and
+the dark editorial theme is PR #5.
 
 ## Done
 
@@ -12,11 +13,12 @@ review. The rebuild is PR #3; its stacked lifecycle alignment is PR #4.
 - Audited the rebuild against the canonical engineering lifecycle at D:\AGENTS.md.
 - Added and verified the lifecycle safety scan and its positive/negative controls.
 - Opened rebuild draft PR #3 and stacked lifecycle draft PR #4.
+- Added the dark editorial theme on stacked draft PR #5.
 
 ## Next
 
-Review and approve the rebuild draft PR first, then review the stacked lifecycle
-draft PR. Do not merge automatically.
+Review and approve the rebuild draft PR first, then the lifecycle draft PR, and
+finally the dark-theme draft PR. Do not merge automatically.
 
 ## Decisions
 
@@ -27,3 +29,5 @@ draft PR. Do not merge automatically.
 - The GitHub integration can push branches but cannot create pull requests.
   GitHub CLI works after gh auth login --hostname github.com --git-protocol https
   --web; use it for future PR creation and verify with gh auth status.
+- A dark default with a system light-mode fallback delivers the requested
+  developer-friendly appearance without JavaScript or a persistent theme setting.

--- a/assets/css/site.css
+++ b/assets/css/site.css
@@ -1,10 +1,122 @@
-:root { --ink: #1e2933; --muted: #62707d; --line: #d8dee4; --paper: #fcfcfb; --accent: #245b78; --code: #f0f3f5; }
-* { box-sizing: border-box; } html { font-size: 100%; }
-body { margin: 0; color: var(--ink); background: var(--paper); font-family: Georgia, "Times New Roman", serif; font-size: 1.125rem; line-height: 1.7; }
-a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: .16em; } a:hover { text-decoration-thickness: 2px; } a:focus-visible { outline: 3px solid #efc76b; outline-offset: 3px; }
-.shell { width: min(100% - 2.5rem, 46rem); margin-inline: auto; }.site-header { border-bottom: 1px solid var(--line); font-family: ui-sans-serif, system-ui, sans-serif; }.header-content { min-height: 5rem; display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; }.site-identity { color: var(--ink); font-weight: 700; text-decoration: none; letter-spacing: -.02em; }.site-nav { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0; padding: 0; list-style: none; font-size: .9rem; }.site-nav a { color: var(--ink); text-decoration: none; }.site-nav a[aria-current="page"] { color: var(--accent); font-weight: 700; }
-main { min-height: calc(100vh - 10rem); padding-block: clamp(3rem, 9vw, 6rem); } h1, h2, h3 { font-family: ui-sans-serif, system-ui, sans-serif; color: #14212b; line-height: 1.2; letter-spacing: -.035em; } h1 { margin: 0; font-size: clamp(2.25rem, 8vw, 4rem); } h2 { margin-top: 3.5rem; font-size: 1.55rem; } h3 { margin: 0; font-size: 1.25rem; } p, ul, ol { margin-block: 1.25rem; }.page-header { margin-bottom: 2rem; }.lede { max-width: 42rem; font-size: clamp(1.3rem, 3vw, 1.6rem); line-height: 1.55; }.eyebrow { margin: 0 0 .4rem; color: var(--muted); font-family: ui-sans-serif, system-ui, sans-serif; font-size: .78rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-.writing-list { border-top: 1px solid var(--line); }.writing-list__item { padding: 1.7rem 0; border-bottom: 1px solid var(--line); }.writing-list__item p:last-child { margin-bottom: 0; }.empty-state, .project-card { margin-top: 1.5rem; padding: 1.5rem; border: 1px solid var(--line); background: #fff; }.empty-state p:last-child, .project-card p:last-child { margin-bottom: 0; }.project-details { margin: 1.5rem 0 0; font-family: ui-sans-serif, system-ui, sans-serif; font-size: .92rem; }.project-details div { display: grid; grid-template-columns: 8rem 1fr; gap: 1rem; padding: .55rem 0; border-top: 1px solid var(--line); }.project-details dt { color: var(--muted); }.project-details dd { margin: 0; }.muted { color: var(--muted); }
-.archive-year { margin-top: 2.5rem; }.archive-list { padding: 0; list-style: none; }.archive-list li { display: grid; grid-template-columns: 5rem 1fr; gap: 1rem; margin-block: .75rem; }.archive-list time { color: var(--muted); font-family: ui-sans-serif, system-ui, sans-serif; font-size: .9rem; }.post-header { margin-bottom: 3rem; }.post-header h1 { margin-bottom: 1rem; }.prose h2 { margin-top: 3rem; }.prose h3 { margin-top: 2.25rem; }.prose blockquote { margin: 2rem 0; padding-left: 1.25rem; border-left: 3px solid var(--accent); color: var(--muted); }.prose pre { overflow-x: auto; padding: 1.25rem; background: var(--code); font-size: .85em; line-height: 1.55; }.prose :not(pre) > code { padding: .1em .35em; background: var(--code); font-size: .88em; }.prose img { max-width: 100%; height: auto; }.post-footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--line); }.tag-list { display: flex; flex-wrap: wrap; gap: .5rem; padding: 0; list-style: none; font-family: ui-sans-serif, system-ui, sans-serif; font-size: .82rem; }.tag-list li { padding: .2rem .55rem; border: 1px solid var(--line); }
-.site-footer { border-top: 1px solid var(--line); color: var(--muted); font-family: ui-sans-serif, system-ui, sans-serif; font-size: .8rem; }.site-footer p { margin: 0; padding-block: 1.5rem; }.skip-link { position: absolute; left: -999px; top: auto; }.skip-link:focus { left: 1rem; top: 1rem; z-index: 2; padding: .5rem .75rem; background: #fff; }.visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
-@media (max-width: 36rem) { .header-content { align-items: flex-start; flex-direction: column; padding-block: 1.25rem; }.project-details div { grid-template-columns: 1fr; gap: .15rem; }.archive-list li { grid-template-columns: 1fr; gap: .1rem; } }
+:root {
+  color-scheme: dark;
+  --ink: #d4d4d4;
+  --heading: #f1f3f5;
+  --muted: #a8b0b9;
+  --line: #3e424a;
+  --paper: #1e1e1e;
+  --surface: #252526;
+  --surface-raised: #2d2d30;
+  --accent: #8cc6ff;
+  --accent-strong: #b4d8ff;
+  --code: #181a1f;
+  --focus: #ffd866;
+}
+
+* { box-sizing: border-box; }
+html { font-size: 100%; }
+body {
+  margin: 0;
+  color: var(--ink);
+  background: var(--paper);
+  font-family: Georgia, "Times New Roman", serif;
+  font-size: 1.125rem;
+  line-height: 1.7;
+}
+
+a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: .16em; }
+a:hover { color: var(--accent-strong); text-decoration-thickness: 2px; }
+a:focus-visible { outline: 3px solid var(--focus); outline-offset: 3px; }
+
+.shell { width: min(100% - 2.5rem, 46rem); margin-inline: auto; }
+.site-header { border-bottom: 1px solid var(--line); background: var(--surface); font-family: ui-sans-serif, system-ui, sans-serif; }
+.header-content { min-height: 5rem; display: flex; align-items: center; justify-content: space-between; gap: 1.5rem; }
+.site-identity { color: var(--heading); font-weight: 700; text-decoration: none; letter-spacing: -.02em; }
+.site-nav { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0; padding: 0; list-style: none; font-size: .9rem; }
+.site-nav a { color: var(--ink); text-decoration: none; }
+.site-nav a:hover { color: var(--heading); }
+.site-nav a[aria-current="page"] { color: var(--accent); font-weight: 700; }
+
+main { min-height: calc(100vh - 10rem); padding-block: clamp(3rem, 9vw, 6rem); }
+h1, h2, h3 {
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--heading);
+  line-height: 1.2;
+  letter-spacing: -.035em;
+}
+h1 { margin: 0; font-size: clamp(2.25rem, 8vw, 4rem); }
+h2 { margin-top: 3.5rem; font-size: 1.55rem; }
+h3 { margin: 0; font-size: 1.25rem; }
+p, ul, ol { margin-block: 1.25rem; }
+.page-header { margin-bottom: 2rem; }
+.lede { max-width: 42rem; font-size: clamp(1.3rem, 3vw, 1.6rem); line-height: 1.55; }
+.eyebrow {
+  margin: 0 0 .4rem;
+  color: var(--muted);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: .78rem;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.writing-list { border-top: 1px solid var(--line); }
+.writing-list__item { padding: 1.7rem 0; border-bottom: 1px solid var(--line); }
+.writing-list__item p:last-child { margin-bottom: 0; }
+.empty-state, .project-card {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid var(--line);
+  background: var(--surface);
+}
+.empty-state p:last-child, .project-card p:last-child { margin-bottom: 0; }
+.project-details { margin: 1.5rem 0 0; font-family: ui-sans-serif, system-ui, sans-serif; font-size: .92rem; }
+.project-details div { display: grid; grid-template-columns: 8rem 1fr; gap: 1rem; padding: .55rem 0; border-top: 1px solid var(--line); }
+.project-details dt, .muted { color: var(--muted); }
+.project-details dd { margin: 0; }
+
+.archive-year { margin-top: 2.5rem; }
+.archive-list { padding: 0; list-style: none; }
+.archive-list li { display: grid; grid-template-columns: 5rem 1fr; gap: 1rem; margin-block: .75rem; }
+.archive-list time { color: var(--muted); font-family: ui-sans-serif, system-ui, sans-serif; font-size: .9rem; }
+
+.post-header { margin-bottom: 3rem; }
+.post-header h1 { margin-bottom: 1rem; }
+.prose h2 { margin-top: 3rem; }
+.prose h3 { margin-top: 2.25rem; }
+.prose blockquote { margin: 2rem 0; padding-left: 1.25rem; border-left: 3px solid var(--accent); color: var(--muted); }
+.prose pre { overflow-x: auto; padding: 1.25rem; border: 1px solid var(--line); background: var(--code); font-size: .85em; line-height: 1.55; }
+.prose :not(pre) > code { padding: .1em .35em; border-radius: .18rem; background: var(--surface-raised); font-size: .88em; }
+.prose img { max-width: 100%; height: auto; }
+.post-footer { margin-top: 4rem; padding-top: 1.5rem; border-top: 1px solid var(--line); }
+.tag-list { display: flex; flex-wrap: wrap; gap: .5rem; padding: 0; list-style: none; font-family: ui-sans-serif, system-ui, sans-serif; font-size: .82rem; }
+.tag-list li { padding: .2rem .55rem; border: 1px solid var(--line); background: var(--surface); }
+
+.site-footer { border-top: 1px solid var(--line); color: var(--muted); background: var(--surface); font-family: ui-sans-serif, system-ui, sans-serif; font-size: .8rem; }
+.site-footer p { margin: 0; padding-block: 1.5rem; }
+.skip-link { position: absolute; left: -999px; top: auto; }
+.skip-link:focus { left: 1rem; top: 1rem; z-index: 2; padding: .5rem .75rem; color: #1e1e1e; background: var(--focus); }
+.visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color-scheme: light;
+    --ink: #26323d;
+    --heading: #17222c;
+    --muted: #5f6d79;
+    --line: #cfd6dc;
+    --paper: #f1f0ec;
+    --surface: #e9e8e4;
+    --surface-raised: #e1e3e5;
+    --accent: #155f96;
+    --accent-strong: #0d4f80;
+    --code: #e3e5e7;
+    --focus: #8c5a00;
+  }
+}
+
+@media (max-width: 36rem) {
+  .header-content { align-items: flex-start; flex-direction: column; padding-block: 1.25rem; }
+  .project-details div { grid-template-columns: 1fr; gap: .15rem; }
+  .archive-list li { grid-template-columns: 1fr; gap: .1rem; }
+}


### PR DESCRIPTION
## Summary

Adds a restrained, developer-friendly dark theme without changing the site structure or adding JavaScript.

- Uses charcoal editor-like surfaces with muted blue accents.
- Preserves readable editorial typography, code-block contrast, focus visibility, and responsive behavior.
- Respects explicit light-mode preference with a softer warm-gray palette instead of a white canvas.

## Validation

- pwsh -NoProfile -File .\test\Test-SafetyScan.ps1 passed.
- Staged diff passed scripts/Invoke-SafetyScan.ps1.
- git diff --check passed.
- Local rendered preview remains blocked because Ruby and Bundler are not installed; CI will run the Jekyll build.

## Stacking

Targets the lifecycle alignment branch so its validation gate remains in the review chain.