### PR TITLE
Establish private editorial workspace boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ vendor/bundle/
 Thumbs.db
 .idea/
 .vscode/
+
+# Local editorial drafts; publish approved work from _posts/ instead.
+/notes/article-draft-*.md
+/notes/article-outline*.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ Thumbs.db
 .idea/
 .vscode/
 
-# Local editorial drafts; publish approved work from _posts/ instead.
+# Article-development artifacts belong in the private editorial workspace.
 /notes/article-draft-*.md
 /notes/article-outline*.md
+/notes/article-evidence*.md
+/notes/evidence*.md
+/notes/mental-models*.md
+/notes/story-brief*.md
+/notes/review*.md

--- a/STATE.md
+++ b/STATE.md
@@ -2,9 +2,9 @@
 
 ## Current
 
-The engineering lifecycle is represented by draft PRs and is ready for human
-review. The rebuild is PR #3, its stacked lifecycle alignment is PR #4, and
-the dark editorial theme is PR #5.
+The public site foundation and dark theme are merged. A draft implementation PR
+now establishes a boundary between the public repository and private editorial
+article development.
 
 ## Done
 
@@ -12,13 +12,16 @@ the dark editorial theme is PR #5.
 - Added GitHub Pages validation and deployment workflows.
 - Audited the rebuild against the canonical engineering lifecycle at D:\AGENTS.md.
 - Added and verified the lifecycle safety scan and its positive/negative controls.
-- Opened rebuild draft PR #3 and stacked lifecycle draft PR #4.
-- Added the dark editorial theme on stacked draft PR #5.
+- Merged the rebuilt site, lifecycle alignment, and dark editorial theme through
+  PR #7.
+- Kept durable public editorial standards in `notes/` while moving article
+  development artifacts to the private editorial workspace.
 
 ## Next
 
-Review and approve the rebuild draft PR first, then the lifecycle draft PR, and
-finally the dark-theme draft PR. Do not merge automatically.
+Review the editorial-workspace boundary draft PR. Keep future evidence, drafts,
+and review material private until a human approves a manual promotion into
+`_posts/`. Do not merge automatically.
 
 ## Decisions
 
@@ -33,3 +36,5 @@ finally the dark-theme draft PR. Do not merge automatically.
   developer-friendly appearance without JavaScript or a persistent theme setting.
 - Safety-scan control tests must explicitly exit successfully after asserting an
   expected failing child process; otherwise that child exit code can fail CI.
+- Article development uses a one-way manual promotion flow: private workspace to
+  approved public post, never automatic synchronization or publishing.

--- a/_config.yml
+++ b/_config.yml
@@ -29,6 +29,9 @@ exclude:
   - Gemfile.lock
   - README.md
   - LICENSE
+  - scripts/
+  - test/
+  - STATE.md
 
 future: false
 unpublished: false

--- a/notes/publishing-checklist.md
+++ b/notes/publishing-checklist.md
@@ -16,6 +16,19 @@
 - [ ] CI passes.
 - [ ] A human has signed off on the final draft.
 
+## Promote an approved article
+
+1. Keep evidence, working outlines, drafts, review notes, and unapproved assets
+   in the private editorial workspace.
+2. After human approval, manually create the public article in `_posts/` using
+   the approved publication copy.
+3. Transfer only approved, public-safe assets into the site's tracked asset
+   directories; do not link or synchronize private workspace folders.
+4. Run the public repository's validation and safety checks, then open a draft
+   implementation PR for human review.
+5. Publishing remains a manual, human-approved step. No script or configuration
+   automatically publishes editorial workspace material.
+
 ## Corrections after publication
 
 Correct meaningful errors promptly. Add a brief, dated correction note when a change affects the article's conclusion, evidence, or recommendation; use a quiet edit for spelling and clarity fixes.


### PR DESCRIPTION
## Summary

- establish a private editorial workspace for article evidence, drafts, templates, and review state
- keep the public repository limited to durable editorial standards and manually promoted approved posts
- prevent Jekyll from copying internal workflow files and ignore future public working-artifact names

## Verification

- `pwsh -NoProfile -File .\test\Test-SafetyScan.ps1`
- staged `Invoke-SafetyScan.ps1` pass against `git diff --cached`
- `git diff --cached --check`
- verified all three private artifact copies by SHA-256 and confirmed the public draft/outline are absent
- confirmed durable public `notes/` files remain tracked and `_posts/` plus `assets/` are not ignored

Local Jekyll rendering was not run because Ruby is not installed; GitHub Actions remains the render and configuration validation gate.