### PR TITLE
Record editorial workspace merge and builder voice

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -2,9 +2,9 @@
 
 ## Current
 
-The public site foundation and dark theme are merged. A draft implementation PR
-now establishes a boundary between the public repository and private editorial
-article development.
+The public site foundation, dark theme, and private editorial-workspace boundary
+are merged. Article development remains private until a human approves a manual
+promotion into the public site.
 
 ## Done
 
@@ -16,12 +16,13 @@ article development.
   PR #7.
 - Kept durable public editorial standards in `notes/` while moving article
   development artifacts to the private editorial workspace.
+- Merged the editorial-workspace boundary through PR #8.
 
 ## Next
 
-Review the editorial-workspace boundary draft PR. Keep future evidence, drafts,
-and review material private until a human approves a manual promotion into
-`_posts/`. Do not merge automatically.
+Keep future evidence, drafts, and review material private until a human approves
+a manual promotion into `_posts/`. Start future public changes from `master` on a
+review branch; do not merge automatically.
 
 ## Decisions
 

--- a/notes/builder-voice.md
+++ b/notes/builder-voice.md
@@ -2,6 +2,8 @@
 
 This blog is not about showing projects.
 
+The article is not the product. It is the artifact of understanding the project.
+
 It is about documenting how engineering judgment evolves.
 
 Every project begins with assumptions.


### PR DESCRIPTION
## Summary

- record that PR #8 merged the private editorial-workspace boundary
- replace the stale draft-PR next step with the ongoing private-to-public promotion flow
- add the builder-voice principle that an article is an artifact of understanding the project

## Verification

- `git diff --check`
- `pwsh -NoProfile -File .\test\Test-SafetyScan.ps1`
- staged `Invoke-SafetyScan.ps1` pass against the state-change diff
- focused builder-voice diff check and safety-scan controls