### PR TITLE
Reconcile Living Room TV publication links

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,4 +28,5 @@ description: Engineering notes from Cesar Rios.
   <p class="eyebrow">In development</p>
   <h3><a href="{{ '/projects/' | relative_url }}#living-room-tv">Living Room TV</a></h3>
   <p>A controller-first interface that turns a Windows desktop into a living-room entertainment system.</p>
+  <p><a href="{{ '/writing/i-thought-i-was-building-a-launcher/' | relative_url }}">Read: I Thought I Was Building a Launcher</a></p>
 </div>

--- a/notes/publishing-checklist.md
+++ b/notes/publishing-checklist.md
@@ -24,9 +24,13 @@
    the approved publication copy.
 3. Transfer only approved, public-safe assets into the site's tracked asset
    directories; do not link or synchronize private workspace folders.
-4. Run the public repository's validation and safety checks, then open a draft
+4. Reconcile related project entries before opening the PR: add the article to
+   related-article links, replace verified repository placeholders, and update
+   relevant homepage project cards. Project status reflects the project itself,
+   not whether an article has been published.
+5. Run the public repository's validation and safety checks, then open a draft
    implementation PR for human review.
-5. Publishing remains a manual, human-approved step. No script or configuration
+6. Publishing remains a manual, human-approved step. No script or configuration
    automatically publishes editorial workspace material.
 
 ## Corrections after publication

--- a/projects.md
+++ b/projects.md
@@ -13,7 +13,7 @@ Projects are a useful record of decisions in motion. The writing is where their 
   <p>A controller-first interface that turns a Windows desktop into a living-room entertainment system.</p>
   <dl class="project-details">
     <div><dt>Status</dt><dd>In development</dd></div>
-    <div><dt>Repository</dt><dd><span class="muted">Repository link to be added</span></dd></div>
-    <div><dt>Related articles</dt><dd>Coming soon</dd></div>
+    <div><dt>Repository</dt><dd><a href="https://github.com/rioscesar/Living-Room-TV">Living Room TV repository</a></dd></div>
+    <div><dt>Related articles</dt><dd><a href="{{ '/writing/i-thought-i-was-building-a-launcher/' | relative_url }}">I Thought I Was Building a Launcher</a></dd></div>
   </dl>
 </section>


### PR DESCRIPTION
## Publication reconciliation report

- Final post: `_posts/2026-07-19-i-thought-i-was-building-a-launcher.md` (unchanged)
- Approved assets added: none
- Repository verified: https://github.com/rioscesar/Living-Room-TV
- Project registry: added repository and related-article links in `projects.md`
- Homepage: added the related-article link to the Living Room TV card
- Project status: intentionally remains `In development`; article publication does not imply project completion
- Process: added project-registry reconciliation to the publishing checklist

## Verification

- `git diff --check`
- article front matter and repository URL checked
- `gh repo view rioscesar/Living-Room-TV --json nameWithOwner,url,isPrivate`
- `pwsh -NoProfile -File .\test\Test-SafetyScan.ps1`
- staged `Invoke-SafetyScan.ps1` pass against the committed diff

Local Jekyll rendering was not run because Ruby is unavailable; GitHub Pages validation is the build gate.